### PR TITLE
feat: add loading bubble in the track chat to improve user experience

### DIFF
--- a/frontend/src/components/specific/kai/loading-bubble.tsx
+++ b/frontend/src/components/specific/kai/loading-bubble.tsx
@@ -1,4 +1,3 @@
-
 export function LoadingBubble() {
   return (
     <div className="flex items-center space-x-2">

--- a/frontend/src/components/specific/tracks/chat-panel.tsx
+++ b/frontend/src/components/specific/tracks/chat-panel.tsx
@@ -1,40 +1,101 @@
-import { useState, useRef } from "react";
+import { useState, useRef} from "react";
 import { Input } from "@/components/ui/input";
-import { InformationCircleIcon, ArrowsPointingOutIcon, XMarkIcon, PaperClipIcon, PaperAirplaneIcon } from "@heroicons/react/24/outline";
+import {
+  InformationCircleIcon,
+  ArrowsPointingOutIcon,
+  XMarkIcon,
+  PaperClipIcon,
+  PaperAirplaneIcon,
+} from "@heroicons/react/24/outline";
 import { ChatSuggestionCard } from "./chat-suggestion-card";
 import { useActor } from "@/lib/agent";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
+import { v4 as uuidv4 } from "uuid";
+import type { Message } from "@/types";
+import { LoadingBubble } from "../kai/loading-bubble";
 
 export function ChatPanel() {
   const [input, setInput] = useState("");
-  const [chat, setChat] = useState([] as { role: "user" | "model"; content: string }[]);
+  const [chat, setChat] = useState<Message[]>([]);
   const [showChat, setShowChat] = useState(false);
+  const [__isLoading, setIsLoading] = useState(false);
 
   const inputRef = useRef<HTMLInputElement>(null);
-  const kaiActor = useActor('kai_backend');
+  const kaiActor = useActor("kai_backend");
 
   const handleSend = () => {
     if (!input.trim()) return;
-    setChat((prev) => [...prev, { role: "user", content: input }]);
+
+    setIsLoading(true);
+    const userMessage: Message = {
+      id: uuidv4(),
+      role: "user",
+      content: input,
+    };
+
+    // Prepara o chat futuro para ser usado tanto na API quanto no estado
+    const newChatHistory = [...chat, userMessage];
+
+    setChat(newChatHistory);
     setInput("");
     setShowChat(true);
 
-    const historyForAI = chat.map(m => `{"role": "${m.role.toLowerCase()}", "parts": [{"text": "${m.content.replace(/"/g, '\\"')}"}]}`)
-      .join(', ');
+    setTimeout(() => {
+      setChat((prev) => [
+        ...prev,
+        { id: uuidv4(), role: "model", content: "", isLoading: true },
+      ]);
+    }, 0);
 
-    kaiActor?.generateChatResponse(
-      input,
-      chat.length > 0 ? [historyForAI] : []
-    )
+    const historyForAI = newChatHistory
+      .map(
+        (m) =>
+          `{"role": "${m.role.toLowerCase()}", "parts": [{"text": "${m.content.replace(
+            /"/g,
+            '\\"'
+          )}"}]}`
+      )
+      .join(", ");
+
+    kaiActor
+      ?.generateChatResponse(input, chat.length > 0 ? [historyForAI] : [])
       .then((response) => {
-        if ('err' in response) {
-          setChat((prev) => [...prev, { role: "model", content: response.err }]);
-          return;
-        }
+        if ("err" in response) {
+          console.error("API Error:", response.err); // Bom para debugar
+          setChat((prev) => {
+            const newMessages = [...prev];
 
-        setChat((prev) => [...prev, { role: "model", content: JSON.parse(response.ok).candidates[0].content.parts[0].text }]);
+            if (newMessages.length > 0) {
+              newMessages[newMessages.length - 1] = {
+                id: uuidv4(),
+                role: "model",
+                content: "Desculpe, ocorreu um erro.",
+              };
+            }
+            return newMessages;
+          });
+        } else {
+          setChat((prev) => {
+            const newMessages = [...prev];
+            if (newMessages.length > 0) {
+              const responseContent =
+                JSON.parse(response.ok)?.candidates?.[0]?.content?.parts?.[0]
+                  ?.text ?? "Não consegui processar a resposta.";
+
+              newMessages[newMessages.length - 1] = {
+                id: uuidv4(),
+                role: "model",
+                content: responseContent,
+              };
+            }
+            return newMessages;
+          });
+        }
       })
+      .finally(() => {
+        setIsLoading(false);
+      });
   };
 
   const handleInputKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
@@ -53,13 +114,19 @@ export function ChatPanel() {
               <ArrowsPointingOutIcon className="h-6 w-6 transition-colors cursor-pointer hover:text-zinc-700" />
             </div>
             <div>
-              <XMarkIcon className="h-6 w-6 text-zinc-500 transition-colors cursor-pointer hover:text-zinc-700" onClick={() => setShowChat(false)} />
+              <XMarkIcon
+                className="h-6 w-6 text-zinc-500 transition-colors cursor-pointer hover:text-zinc-700"
+                onClick={() => setShowChat(false)}
+              />
             </div>
           </div>
           <div className="flex flex-col gap-2 mt-2">
-            {chat.map((msg, idx) => (
+            {chat.map((msg, idx) =>
               msg.role === "model" ? (
-                <div key={idx} className="flex gap-2 self-start max-w-[80%] items-center justify-center">
+                <div
+                  key={idx}
+                  className="flex gap-2 self-start max-w-[80%] items-center justify-center"
+                >
                   <img
                     src="/kai-sitting.svg"
                     alt="Kai"
@@ -68,17 +135,24 @@ export function ChatPanel() {
                     className="mb-1"
                   />
                   <div className="bg-zinc-300 text-zinc-900 px-4 py-2 rounded-xl">
-                    <ReactMarkdown remarkPlugins={[remarkGfm]}>
-                      {msg.content}
-                    </ReactMarkdown>
+                    {msg.isLoading ? (
+                      <LoadingBubble />
+                    ) : (
+                      <ReactMarkdown remarkPlugins={[remarkGfm]}>
+                        {msg.content}
+                      </ReactMarkdown>
+                    )}
                   </div>
                 </div>
               ) : (
-                <div key={idx} className="self-end bg-zinc-800 text-white px-4 py-2 rounded-xl max-w-[70%]">
+                <div
+                  key={idx}
+                  className="self-end bg-zinc-800 text-white px-4 py-2 rounded-xl max-w-[70%]"
+                >
                   {msg.content}
                 </div>
               )
-            ))}
+            )}
           </div>
         </div>
       ) : (
@@ -100,7 +174,9 @@ export function ChatPanel() {
             className="-mt-6"
           />
           <h1 className="font-semibold text-lg">Kai</h1>
-          <p className="text-zinc-400 text-base mb-6">Your AI study partner right here</p>
+          <p className="text-zinc-400 text-base mb-6">
+            Your AI study partner right here
+          </p>
           <div className="w-full flex flex-col gap-3">
             <ChatSuggestionCard
               title="Explain this concept"
@@ -125,7 +201,7 @@ export function ChatPanel() {
         <Input
           ref={inputRef}
           value={input}
-          onChange={e => setInput(e.target.value)}
+          onChange={(e) => setInput(e.target.value)}
           onKeyDown={handleInputKeyDown}
           placeholder="How can I help you?"
           className="pr-16 !bg-transparent h-12"


### PR DESCRIPTION
# Description
This PR enhances the user experience (UX) in the Kai AI chat by introducing a visual loading indicator. Previously, the user sent a message and had to wait for the AI's response without any visual feedback, which could create uncertainty.

With this update, a LoadingBubble component is now displayed immediately after a message is submitted, providing clear and instantaneous confirmation that the request is being processed. This change makes the interface feel more responsive and keeps the user informed about the status of their query.

# Key Changes 📑:
- State Logic Enhancement:

  - The existing state management was updated to control the visibility of the loading indicator.

  - A placeholder message with an isLoading: true flag is added to the chat history immediately upon sending a user message.

  - The UI conditionally renders the LoadingBubble for this placeholder message.

  - When the final AI response (or an error) is received from the backend, this placeholder is replaced with the actual content, and the isLoading flag is removed, causing the loading bubble to disappear.

# Reviewers 👥
@jlimaz - Frontend developer & UX/UI specialist

@m4rcusml - FullStack developer

# Testing 📔
To ensure the new loading feature is working correctly, please perform the following checks:

[ ] Navigate to the /kai route and start a conversation.

[ ] Send a Message: Type a message and press Enter, or click on a suggestion card.

- Verify Loading State:

[ ] Confirm that your message appears instantly in the chat.

[ ] Crucially, verify that the LoadingBubble appears right below it, indicating the AI is processing.

- Verify Response State:

[ ] Confirm that after a few seconds, the LoadingBubble is smoothly replaced by the actual AI response.

[ ] Test Subsequent Messages: Send multiple messages in a row and ensure the loading indicator behaves correctly for each one.

# 🖼️ Screenshot:

<img width="1872" height="978" alt="image" src="https://github.com/user-attachments/assets/d043fbfa-0fbd-4cc9-bf90-c19f79eba0df" />

