### PR TITLE
Feat/progressive track

### DIFF
--- a/backend/users/Types.mo
+++ b/backend/users/Types.mo
@@ -1,12 +1,12 @@
 import Time "mo:base/Time";
 
 module {
-  type FollowerData = {
+  public type FollowerData = {
     userIdentity : Text;
     timestamp : Time.Time;
   };
 
-  type InProgressTracksData = {
+  public type InProgressTracksData = {
     id : Text;
     progress : Nat8;
   };

--- a/backend/users/main.mo
+++ b/backend/users/main.mo
@@ -1,12 +1,51 @@
+
 import TrieMap "mo:base/TrieMap";
 import Text "mo:base/Text";
 import Result "mo:base/Result";
 import Iter "mo:base/Iter";
 import Types "./Types";
+import Nat "mo:base/Nat";
+import Nat8 "mo:base/Nat8";
 
 persistent actor {
   private transient var users : TrieMap.TrieMap<Text, Types.User> = TrieMap.TrieMap(Text.equal, Text.hash);
-  var stableUsers : [(Text, Types.User)] = [];
+  transient var stableUsers : [(Text, Types.User)] = [];
+
+  // Função auxiliar para checar se o usuário pode acessar a seção desejada
+  private func canAccessSection(user : Types.User, trackId : Text, sectionId : Nat) : Bool {
+    var progress : ?Types.InProgressTracksData = null;
+    label search for (trk in user.inProgressTracks.vals()) {
+      if (trk.id == trackId) {
+        progress := ?trk;
+        break search;
+      }
+    };
+    switch (progress) {
+      case null {
+        // Se não há progresso, só pode acessar a primeira seção
+        return sectionId == 1;
+      };
+      case (?p) {
+        // Só pode acessar a próxima seção se a anterior foi concluída
+  return sectionId <= Nat8.toNat(p.progress) + 1;
+      }
+    }
+  };
+
+  // ...existing code...
+  // Função pública para tentar acessar/iniciar uma seção
+  public func tryAccessSection(identity : Text, trackId : Text, sectionId : Nat) : async Result.Result<(), Text> {
+    switch (users.get(identity)) {
+      case null { return #err("Usuário não encontrado."); };
+      case (?user) {
+        if (canAccessSection(user, trackId, sectionId)) {
+          return #ok;
+        } else {
+          return #err("Você precisa concluir a seção anterior antes de acessar esta.");
+        }
+      }
+    }
+  };
 
   system func preupgrade() {
     stableUsers := Iter.toArray(users.entries());
@@ -20,7 +59,6 @@ persistent actor {
     if (users.get(user.identity) != null) {
       return #err("Usuário já existe com esse identity.");
     };
-
     users.put(user.identity, user);
     return #ok;
   };
@@ -29,7 +67,7 @@ persistent actor {
     switch (users.get(identity)) {
       case (?user) { return #ok(user) };
       case null { return #err("Usuário nao encontrado.") };
-    };
+    }
   };
 
   public func updateUser(user : Types.User) : async Result.Result<(), Text> {
@@ -38,14 +76,14 @@ persistent actor {
       case _ {
         users.put(user.identity, user);
         return #ok;
-      };
-    };
+      }
+    }
   };
 
   public func deleteUser(identity : Text) : async Result.Result<(), Text> {
     switch (users.remove(identity)) {
       case null { return #err("Usuário não encontrado.") };
       case _ { return #ok };
-    };
+    }
   };
 };

--- a/frontend/src/components/general/page-header/page-header.tsx
+++ b/frontend/src/components/general/page-header/page-header.tsx
@@ -21,7 +21,7 @@ interface PageHeaderProps extends React.HTMLAttributes<HTMLDivElement> {
 export const PageHeader = React.forwardRef<HTMLDivElement, PageHeaderProps>(
   ({ className, title, subtitle, showBackButton = true, onBackClick, tabs, baseUrl, imageUrl, imageFallback, showBgImage = true, headerClassname, ...props }, ref) => {
     return (
-      <header className={cn("relative w-full px-8 pt-12 bg-background", headerClassname)}>
+      <header className={cn("relative w-full px-8 pt-12 bg-zinc-950 border-b-2 border-zinc-800", headerClassname)}>
         {showBgImage &&
           (<div className="absolute pointer-events-none select-none right-0 top-0 w-96 h-[75%] lg:h-full">
             <img

--- a/frontend/src/components/specific/modal-presets/loading.tsx
+++ b/frontend/src/components/specific/modal-presets/loading.tsx
@@ -3,7 +3,6 @@ import {
   AlertDialogDescription,
   AlertDialogTitle
 } from '@/components/ui/alert-dialog'
-import { Progress } from '@/components/ui/progress'
 
 interface Props {
   progress?: number
@@ -18,14 +17,11 @@ export function LoadingPreset({ progress }: Props) {
           alt="loading"
           width={64}
           height={64}
-          className="animate-spin"
+          className="slow-spin"
         />
       </AlertDialogTitle>
       <AlertDialogDescription>
       </AlertDialogDescription>
-      {progress ?? (
-        <Progress className="mt-2 w-sm h-4" color="bg-white" value={progress} />
-      )}
     </AlertDialogContent>
   )
 }

--- a/frontend/src/components/specific/modal-presets/loading.tsx
+++ b/frontend/src/components/specific/modal-presets/loading.tsx
@@ -4,11 +4,7 @@ import {
   AlertDialogTitle
 } from '@/components/ui/alert-dialog'
 
-interface Props {
-  progress?: number
-}
-
-export function LoadingPreset({ progress }: Props) {
+export function LoadingPreset() {
   return (
     <AlertDialogContent className="outline-none w-16 flex flex-col items-center p-0 border-none bg-transparent">
       <AlertDialogTitle>

--- a/frontend/src/components/specific/modal-presets/track-content-section.tsx
+++ b/frontend/src/components/specific/modal-presets/track-content-section.tsx
@@ -1,5 +1,4 @@
 import { type Page, type PageElement } from '@/types'
-import { useModalStore } from '@/stores/useModalStore'
 import { Button } from '@/components/ui/button'
 import {
   DialogContent,
@@ -12,6 +11,8 @@ import {
 interface Props {
   title: string
   pageData: Page
+  onComplete?: (() => void) | null
+  isCompleted?: boolean
 }
 
 function ElementRenderer({ element }: { element: PageElement }) {
@@ -60,8 +61,7 @@ function ElementRenderer({ element }: { element: PageElement }) {
   return null
 }
 
-export function ContentSectionPreset({ title, pageData }: Props) {
-  const { close } = useModalStore()
+export function ContentSectionPreset({ title, pageData, onComplete, isCompleted }: Props) {
 
   return (
     <DialogContent showCloseButton={false} className="sm:max-w-4xl h-[80vh] overflow-y-auto p-8" style={{ borderColor: 'var(--border)' }}>
@@ -77,9 +77,16 @@ export function ContentSectionPreset({ title, pageData }: Props) {
       </div>
 
       <DialogFooter className="">
-        <Button onClick={close}>
-          Mark as done
-        </Button>
+        {onComplete && (
+          <Button
+            variant={isCompleted ? 'secondary' : 'default'}
+            className='mt-2 cursor-pointer'
+            onClick={onComplete}
+            disabled={isCompleted}
+          >
+            {isCompleted ? 'Concluída' : 'Mark as Done'}
+          </Button>
+        )}
       </DialogFooter>
     </DialogContent>
   )

--- a/frontend/src/components/specific/modal-presets/track-content-section.tsx
+++ b/frontend/src/components/specific/modal-presets/track-content-section.tsx
@@ -39,9 +39,15 @@ function ElementRenderer({ element }: { element: PageElement }) {
   if ('Video' in element) {
     return (
       <figure className="my-4">
-        <video src={element.Video.url} controls className="rounded-md border w-full">
-          Seu navegador não suporta o elemento de vídeo.
-        </video>
+        <div className="relative w-full pb-[56.25%]">
+          <video
+            src={element.Video.url}
+            controls
+            className="absolute top-0 left-0 w-full h-full rounded-md border-2 border-muted"
+          >
+            Seu navegador não suporta o elemento de vídeo.
+          </video>
+        </div>
         {element.Video.caption && (
           <figcaption className="text-center text-sm text-muted-foreground mt-2">
             {element.Video.caption}
@@ -58,7 +64,7 @@ export function ContentSectionPreset({ title, pageData }: Props) {
   const { close } = useModalStore()
 
   return (
-    <DialogContent showCloseButton={false} className="sm:max-w-3xl max-h-[80vh] overflow-y-auto" style={{ borderColor: 'var(--border)' }}>
+    <DialogContent showCloseButton={false} className="sm:max-w-4xl h-[80vh] overflow-y-auto p-8" style={{ borderColor: 'var(--border)' }}>
       <DialogHeader>
         <DialogTitle className="text-2xl">{title}</DialogTitle>
         <DialogDescription>{pageData.title}</DialogDescription>
@@ -70,9 +76,9 @@ export function ContentSectionPreset({ title, pageData }: Props) {
         ))}
       </div>
 
-      <DialogFooter>
+      <DialogFooter className="">
         <Button onClick={close}>
-          Marcar como lida
+          Mark as done
         </Button>
       </DialogFooter>
     </DialogContent>

--- a/frontend/src/components/specific/modal-presets/track-essay-section.tsx
+++ b/frontend/src/components/specific/modal-presets/track-essay-section.tsx
@@ -12,9 +12,11 @@ import remarkGfm from 'remark-gfm'
 interface Props {
   title: string
   pageData: Essay[]
+  onComplete?: (() => void) | null
+  isCompleted?: boolean
 }
 
-export function EssaySectionPreset({ title, pageData }: Props) {
+export function EssaySectionPreset({ title, pageData, onComplete, isCompleted }: Props) {
   const kaiActor = useActor('kai_backend')
 
   const [currentQuestion, setCurrentQuestion] = useState(0)
@@ -87,14 +89,14 @@ Diga se a resposta está correta ou incorreta e explique o porquê. Retorne uma 
     setAiFeedback('')
   }
 
-  const handleRestart = () => {
-    setCurrentQuestion(0)
-    setAnswer('')
-    setAiFeedback('')
-    setCorrectAnswers(0)
-    setShowResult(false)
-    setAnsweredQuestions([])
-  }
+  // const handleRestart = () => {
+  //   setCurrentQuestion(0)
+  //   setAnswer('')
+  //   setAiFeedback('')
+  //   setCorrectAnswers(0)
+  //   setShowResult(false)
+  //   setAnsweredQuestions([])
+  // }
 
   return (
     <DialogContent className='sm:max-w-4xl h-[80vh] overflow-y-auto p-8 flex flex-col' style={{ borderColor: 'var(--border)' }}>
@@ -160,9 +162,16 @@ Diga se a resposta está correta ou incorreta e explique o porquê. Retorne uma 
             </div>
           </>
         ) : (
-          <Button className='absolute bottom-8'>
-            Mark as done
-          </Button>
+          onComplete && (
+            <Button
+              variant={isCompleted ? 'secondary' : 'default'}
+              className='absolute bottom-8 mt-2 cursor-pointer'
+              onClick={onComplete}
+              disabled={isCompleted}
+            >
+              {isCompleted ? 'Concluída' : 'Mark as done'}
+            </Button>
+          )
         )}
 
         <Progress

--- a/frontend/src/components/specific/modal-presets/track-essay-section.tsx
+++ b/frontend/src/components/specific/modal-presets/track-essay-section.tsx
@@ -97,7 +97,7 @@ Diga se a resposta está correta ou incorreta e explique o porquê. Retorne uma 
   }
 
   return (
-    <DialogContent style={{ borderColor: 'var(--border)' }}>
+    <DialogContent className='sm:max-w-4xl h-[80vh] overflow-y-auto p-8 flex flex-col' style={{ borderColor: 'var(--border)' }}>
       <DialogHeader>
         <DialogTitle className="text-2xl">
           {title}
@@ -116,17 +116,16 @@ Diga se a resposta está correta ou incorreta e explique o porquê. Retorne uma 
 
       {!showResult && (
         <>
-          <div className="mb-2">
-            <Textarea
-              placeholder="Digite sua resposta aqui"
-              className="min-h-40"
-              value={answer}
-              onChange={(e) => setAnswer(e.target.value)}
-              disabled={aiFeedback !== ""}
-            />
-          </div>
-
-          {aiFeedback && (
+          {aiFeedback === "" ? (
+            <div className="mb-2">
+              <Textarea
+                placeholder="Digite sua resposta aqui"
+                className="min-h-60 max-h-95"
+                value={answer}
+                onChange={(e) => setAnswer(e.target.value)}
+              />
+            </div>
+          ) : (
             <div className={cn(
               'p-4 rounded-md text-sm',
               aiFeedback.toLowerCase().startsWith('correto') ? 'bg-green-500/10 text-green-500' : 'bg-red-500/10 text-red-500'
@@ -142,26 +141,27 @@ Diga se a resposta está correta ou incorreta e explique o porquê. Retorne uma 
       <DialogFooter className="mt-2 pb-4">
         {!showResult ? (
           <>
-            <Button
-              className="flex-1"
-              onClick={aiFeedback ? handleNext : handleCheckAnswer}
-              disabled={loading || (answer.trim() === "" && aiFeedback === "")}
-            >
-              {aiFeedback ? (isLastQuestion ? 'Finalizar' : 'Próximo') : (loading ? 'Corrigindo...' : 'Enviar')}
-            </Button>
-
-            <Button
-              className="flex-1"
-              variant="outline"
-              onClick={handleClear}
-              disabled={loading}
-            >
-              {aiFeedback ? 'Try again' : 'Clear'}
-            </Button>
+            <div className='absolute bottom-8 flex gap-2'>
+              <Button
+                className="flex-1"
+                onClick={aiFeedback ? handleNext : handleCheckAnswer}
+                disabled={loading || (answer.trim() === "" && aiFeedback === "")}
+              >
+                {aiFeedback ? (isLastQuestion ? 'Finish' : 'Next') : (loading ? 'Checking your answer...' : 'Correct')}
+              </Button>
+              <Button
+                className="flex-1"
+                variant="outline"
+                onClick={handleClear}
+                disabled={loading}
+              >
+                {aiFeedback ? 'Try again' : 'Clear'}
+              </Button>
+            </div>
           </>
         ) : (
-          <Button onClick={handleRestart}>
-            Reiniciar Quiz
+          <Button className='absolute bottom-8'>
+            Mark as done
           </Button>
         )}
 

--- a/frontend/src/components/specific/modal-presets/track-flashcards-section.tsx
+++ b/frontend/src/components/specific/modal-presets/track-flashcards-section.tsx
@@ -14,7 +14,7 @@ export function FlashcardSectionPreset({ title, flashcards = [] }: Props) {
 
   return (
     <DialogContent className="sm:max-w-md bg-transparent border-none p-0 text-white">
-      <DialogHeader className="bg-zinc-900 border-zinc-800 border-2 p-4 rounded-2xl">
+      <DialogHeader className="bg-zinc-900 border-zinc-800 border-2 p-6 rounded-2xl">
         <DialogTitle>{title}</DialogTitle>
         <DialogDescription>
           {flashcards.length > 0 ? 'Clique no card para virar.' : 'Nenhum card nesta seção.'}
@@ -31,15 +31,9 @@ export function FlashcardSectionPreset({ title, flashcards = [] }: Props) {
         />
       </div>
 
-      <DialogFooter className="flex justify-between sm:justify-around items-center w-full">
-        <div className="bg-zinc-900 border-zinc-800 border-2 px-4 py-2 rounded-2xl">
-          <span className="text-lg">
-            <span className="text-zinc-400 text-sm">Tempo:</span> 00:00
-          </span>
-        </div>
-
+      <DialogFooter className="flex items-end w-full">
         <Button className="cursor-pointer" onClick={close}>
-          Marcar como concluída
+          Mask as done
         </Button>
       </DialogFooter>
     </DialogContent>

--- a/frontend/src/components/specific/modal-presets/track-flashcards-section.tsx
+++ b/frontend/src/components/specific/modal-presets/track-flashcards-section.tsx
@@ -1,5 +1,5 @@
 import { DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog'
-import { useModalStore } from '@/stores/useModalStore'
+
 import { FlashcardDeck } from '@/components/specific/tracks/flashcard-deck'
 import { Button } from '@/components/ui/button'
 import { type Flashcard } from '@/types'
@@ -7,11 +7,11 @@ import { type Flashcard } from '@/types'
 interface Props {
   title: string
   flashcards: Flashcard[]
+  onComplete?: (() => void) | null
+  isCompleted?: boolean
 }
 
-export function FlashcardSectionPreset({ title, flashcards = [] }: Props) {
-  const { close } = useModalStore()
-
+export function FlashcardSectionPreset({ title, flashcards = [], onComplete, isCompleted }: Props) {
   return (
     <DialogContent className="sm:max-w-md bg-transparent border-none p-0 text-white">
       <DialogHeader className="bg-zinc-900 border-zinc-800 border-2 p-6 rounded-2xl">
@@ -32,9 +32,16 @@ export function FlashcardSectionPreset({ title, flashcards = [] }: Props) {
       </div>
 
       <DialogFooter className="flex items-end w-full">
-        <Button className="cursor-pointer" onClick={close}>
-          Mask as done
-        </Button>
+        {onComplete && (
+          <Button
+            variant={isCompleted ? 'secondary' : 'default'}
+            className='mt-2 cursor-pointer'
+            onClick={onComplete}
+            disabled={isCompleted}
+          >
+            {isCompleted ? 'Concluída' : 'Mark as done'}
+          </Button>
+        )}
       </DialogFooter>
     </DialogContent>
   )

--- a/frontend/src/components/specific/modal-presets/track-quiz-section.tsx
+++ b/frontend/src/components/specific/modal-presets/track-quiz-section.tsx
@@ -8,9 +8,11 @@ import { DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTit
 interface Props {
   title: string
   pageData: Quiz[]
+  onComplete?: (() => void) | null
+  isCompleted?: boolean
 }
 
-export function QuizSectionPreset({ title, pageData }: Props) {
+export function QuizSectionPreset({ title, pageData, onComplete, isCompleted }: Props) {
   const [currentQuestion, setCurrentQuestion] = useState(0)
   const [selected, setSelected] = useState<number | null>(null)
   const [correctAnswers, setCorrectAnswers] = useState(0)
@@ -49,13 +51,13 @@ export function QuizSectionPreset({ title, pageData }: Props) {
     setSelected(null)
   }
 
-  const handleReset = () => {
-    setCurrentQuestion(0)
-    setSelected(null)
-    setCorrectAnswers(0)
-    setAnsweredQuestions([])
-    setShowResult(false)
-  }
+  // const handleReset = () => {
+  //   setCurrentQuestion(0)
+  //   setSelected(null)
+  //   setCorrectAnswers(0)
+  //   setAnsweredQuestions([])
+  //   setShowResult(false)
+  // }
 
   return (
     <DialogContent className='sm:max-w-4xl h-[80vh] overflow-y-auto p-8 flex flex-col' style={{ borderColor: 'var(--border)' }}>
@@ -122,9 +124,16 @@ export function QuizSectionPreset({ title, pageData }: Props) {
             </div>
           </>
         ) : (
-          <Button className='absolute bottom-8'>
-            Mark as done
-          </Button>
+          onComplete && (
+            <Button
+              variant={isCompleted ? 'secondary' : 'default'}
+              className='absolute bottom-8 mt-2 cursor-pointer'
+              onClick={onComplete}
+              disabled={isCompleted}
+            >
+              {isCompleted ? 'Concluída' : 'Mark as done'}
+            </Button>
+          )
         )}
 
         <Progress

--- a/frontend/src/components/specific/modal-presets/track-quiz-section.tsx
+++ b/frontend/src/components/specific/modal-presets/track-quiz-section.tsx
@@ -58,25 +58,25 @@ export function QuizSectionPreset({ title, pageData }: Props) {
   }
 
   return (
-    <DialogContent style={{ borderColor: 'var(--border)' }}>
+    <DialogContent className='sm:max-w-4xl h-[80vh] overflow-y-auto p-8 flex flex-col' style={{ borderColor: 'var(--border)' }}>
       <DialogHeader>
         <DialogTitle className="text-2xl">
           {title}
         </DialogTitle>
 
         {!showResult ? (
-          <DialogDescription className="text-base text-foreground">
+          <DialogDescription className="text-base text-foreground mb-4">
             {`${currentQuestion + 1}. ${question.question}`}
           </DialogDescription>
         ) : (
-          <DialogDescription className="text-base text-foreground">
+          <DialogDescription className="text-base text-foreground mb-4">
             Você acertou {correctAnswers} de {pageData.length} questões.
           </DialogDescription>
         )}
       </DialogHeader>
 
       {!showResult && (
-        <div className="flex flex-col gap-2 mb-2">
+        <div className="flex flex-col gap-2">
           {question.alternatives.map((alt, index) => {
             const isSelected = selected === index
             const isCorrect = alt.id === question.correctAnswerId
@@ -112,17 +112,18 @@ export function QuizSectionPreset({ title, pageData }: Props) {
       <DialogFooter>
         {!showResult ? (
           <>
-            <Button variant="outline" onClick={handlePrev} disabled={currentQuestion === 0}>
-              Voltar
-            </Button>
-
-            <Button onClick={handleNext} disabled={selected === null}>
-              {isLastQuestion ? 'Finalizar' : 'Próximo'}
-            </Button>
+            <div className='absolute bottom-8 flex gap-2'>
+              <Button variant="outline" onClick={handlePrev} disabled={currentQuestion === 0}>
+                Voltar
+              </Button>
+              <Button onClick={handleNext} disabled={selected === null}>
+                {isLastQuestion ? 'Finalizar' : 'Próximo'}
+              </Button>
+            </div>
           </>
         ) : (
-          <Button onClick={handleReset}>
-            Reiniciar Quiz
+          <Button className='absolute bottom-8'>
+            Mark as done
           </Button>
         )}
 

--- a/frontend/src/components/specific/tracks/flashcard-deck.tsx
+++ b/frontend/src/components/specific/tracks/flashcard-deck.tsx
@@ -89,7 +89,7 @@ export function FlashcardDeck({
                 }}
               >
                 {/* Frente */}
-                <div className={`absolute w-full h-full flex flex-col justify-center items-center p-8 bg-zinc-900 border border-zinc-800 rounded-xl [backface-visibility:hidden] ${isTopCard ? '[box-shadow:0px_0px_50px_2px_rgba(194,65,12,0.11)_inset]' : ''}`}>
+                <div className={`absolute w-full h-full flex flex-col justify-center items-center p-8 bg-zinc-900 border border-zinc-800 rounded-xl [backface-visibility:hidden] ${isTopCard ? '[box-shadow:0px_0px_25px_2px_rgba(194,65,12,0.065)_inset]' : ''}`}>
                   <p className="text-center text-xl text-zinc-100">{card.sentence}</p>
                   <div className="flex justify-between items-center absolute bottom-4 w-full px-6">
                     <div className='text-zinc-500'>
@@ -109,7 +109,7 @@ export function FlashcardDeck({
                 </div>
 
                 {/* Verso */}
-                <div className="absolute w-full h-full flex flex-col justify-center items-center p-8 bg-zinc-800 border border-zinc-700 rounded-xl [transform:rotateY(180deg)] [backface-visibility:hidden]">
+                <div className="absolute w-full h-full flex flex-col justify-center items-center p-8 bg-zinc-900 border border-zinc-800 rounded-xl [transform:rotateY(180deg)] [backface-visibility:hidden]">
                   <p className="text-center text-xl font-semibold text-white">{card.answer}</p>
                 </div>
               </motion.div>

--- a/frontend/src/components/specific/tracks/section-card.tsx
+++ b/frontend/src/components/specific/tracks/section-card.tsx
@@ -7,9 +7,11 @@ interface SectionCardProps {
   className?: string;
   style?: React.CSSProperties;
   onClick?: () => void;
+  onComplete?: (() => void) | null;
+  isCompleted?: boolean;
 }
 
-export function SectionCard({ title, description, buttonText, onClick, className, style }: SectionCardProps) {
+export function SectionCard({ title, description, buttonText, onClick, className, style, onComplete, isCompleted }: SectionCardProps) {
   return (
     <div style={style} className={`absolute cursor-default ${className}`}>
       <div className='flex flex-col gap-2 bg-card w-80 p-6 border-2 border-zinc-800 rounded-2xl'>
@@ -20,6 +22,16 @@ export function SectionCard({ title, description, buttonText, onClick, className
         <Button variant='outline' className='mt-4 cursor-pointer' onClick={onClick}>
           {buttonText}
         </Button>
+        {onComplete && (
+          <Button
+            variant={isCompleted ? 'default' : 'secondary'}
+            className='mt-2 cursor-pointer'
+            onClick={onComplete}
+            disabled={isCompleted}
+          >
+            {isCompleted ? 'Concluída' : 'Marcar como concluída'}
+          </Button>
+        )}
       </div>
     </div>
   );

--- a/frontend/src/components/specific/tracks/section-card.tsx
+++ b/frontend/src/components/specific/tracks/section-card.tsx
@@ -7,11 +7,9 @@ interface SectionCardProps {
   className?: string;
   style?: React.CSSProperties;
   onClick?: () => void;
-  onComplete?: (() => void) | null;
-  isCompleted?: boolean;
 }
 
-export function SectionCard({ title, description, buttonText, onClick, className, style, onComplete, isCompleted }: SectionCardProps) {
+export function SectionCard({ title, description, buttonText, onClick, className, style }: SectionCardProps) {
   return (
     <div style={style} className={`absolute cursor-default ${className}`}>
       <div className='flex flex-col gap-2 bg-card w-80 p-6 border-2 border-zinc-800 rounded-2xl'>
@@ -22,16 +20,6 @@ export function SectionCard({ title, description, buttonText, onClick, className
         <Button variant='outline' className='mt-4 cursor-pointer' onClick={onClick}>
           {buttonText}
         </Button>
-        {onComplete && (
-          <Button
-            variant={isCompleted ? 'default' : 'secondary'}
-            className='mt-2 cursor-pointer'
-            onClick={onComplete}
-            disabled={isCompleted}
-          >
-            {isCompleted ? 'Concluída' : 'Marcar como concluída'}
-          </Button>
-        )}
       </div>
     </div>
   );

--- a/frontend/src/components/ui/global-modal.tsx
+++ b/frontend/src/components/ui/global-modal.tsx
@@ -25,6 +25,8 @@ export function GlobalModal() {
             <ContentSectionPreset
               title={payload.data.title}
               pageData={payload.data.content.Page}
+              onComplete={payload.data.onComplete}
+              isCompleted={payload.data.isCompleted}
             />
           );
         }
@@ -33,6 +35,8 @@ export function GlobalModal() {
             <FlashcardSectionPreset
               title={payload.data.title}
               flashcards={payload.data.content.Flashcard}
+              onComplete={payload.data.onComplete}
+              isCompleted={payload.data.isCompleted}
             />
           );
         }
@@ -41,6 +45,8 @@ export function GlobalModal() {
             <QuizSectionPreset
               title={payload.data.title}
               pageData={payload.data.content.Quiz}
+              onComplete={payload.data.onComplete}
+              isCompleted={payload.data.isCompleted}
             />
           );
         }
@@ -49,6 +55,8 @@ export function GlobalModal() {
             <EssaySectionPreset
               title={payload.data.title}
               pageData={payload.data.content.Essay}
+              onComplete={payload.data.onComplete}
+              isCompleted={payload.data.isCompleted}
             />
           );
         }

--- a/frontend/src/globals.css
+++ b/frontend/src/globals.css
@@ -181,3 +181,13 @@
     linear-gradient(to bottom, hsl(var(--border) / 0.4) 1px, transparent 1px);
   background-size: 30px 30px; /* You can adjust the grid size here */
 }
+
+/* Slow spin animation for loading indicator */
+.slow-spin {
+  animation: spin 2s linear infinite !important;
+}
+
+@keyframes spin {
+  0% { transform: rotate(0deg); }
+  100% { transform: rotate(360deg); }
+}

--- a/frontend/src/pages/tracks/index.tsx
+++ b/frontend/src/pages/tracks/index.tsx
@@ -65,7 +65,7 @@ export default function TrackPage() {
     }
   }, [selectedTrack, tracks])
 
-  const handleSectionClick = async (section: Section) => {
+  const handleSectionClick = async (section: Section, isActive?: boolean, isCompleted?: boolean) => {
     if (!usersActor || !user) {
       toast.error('Usuário não autenticado.')
       return
@@ -75,7 +75,14 @@ export default function TrackPage() {
       toast.error(res.err)
       return
     }
-    open({ type: 'section', data: section })
+    open({
+      type: 'section',
+      data: {
+        ...section,
+        onComplete: isActive ? () => handleCompleteSection(section) : null,
+        isCompleted
+      }
+    })
   }
 
   // Função para marcar seção como concluída
@@ -147,10 +154,8 @@ export default function TrackPage() {
                     title={section.title}
                     description={`Seção ${section.id} da trilha.`}
                     buttonText={getButtonTextForContent(section.content)}
-                    onClick={() => handleSectionClick(section)}
+                    onClick={() => handleSectionClick(section, isActive, isCompleted)}
                     style={section.position}
-                    onComplete={isActive ? () => handleCompleteSection(section) : null}
-                    isCompleted={isCompleted}
                   />
                 );
               })}

--- a/frontend/src/stores/useModalStore.ts
+++ b/frontend/src/stores/useModalStore.ts
@@ -2,7 +2,7 @@ import { create } from 'zustand'
 import { type Section } from '@/types'
 
 type ModalPayload =
-  | { type: 'section'; data: Section, useAlertDialog?: boolean }
+  | { type: 'section'; data: Section & { onComplete?: (() => void) | null; isCompleted?: boolean }, useAlertDialog?: boolean }
   | { type: 'choose-section-content'; useAlertDialog?: boolean }
   | { type: 'create-track'; navigate: (route: string) => void, useAlertDialog?: boolean }
   | {


### PR DESCRIPTION
# Enforce Sequential Track Progression & Enhance Section UI

## Summary
This PR adds **sequential section access control** and **completion tracking** to all track content types (content, quiz, essay, flashcards), alongside consistent UI/UX improvements in modals.

## Key Changes
### Backend
- Added `canAccessSection` and `tryAccessSection` in `main.mo` to enforce progression rules.
- Made `FollowerData` and `InProgressTracksData` public in `Types.mo`.
- Refactored `main.mo` for consistent style.

### Frontend
- All section modals now support `onComplete` and `isCompleted` for tracking and disabling completed sections.
- Improved layout, button placement, and labeling for consistency.
- Enhanced video responsiveness in content modals.
- Added progress tracking and conditional rendering in quiz/essay modals.
- Updated flashcard UI and removed unused timer.

### General UI
- Refined `PageHeader` background and border.
- Simplified loading modal with custom slow-spin animation.
- Adjusted flashcard deck shadows for better clarity.

## Impact
- Ensures **ordered learning flow** by locking future sections until prior ones are completed.
- Improves **feedback and clarity** for learners.
- Delivers a **more consistent and responsive UI** across all track content.
